### PR TITLE
add net and first object, remove some example code

### DIFF
--- a/game.py
+++ b/game.py
@@ -1,5 +1,9 @@
-# Example file showing a circle moving on screen
+# This game was made in part by following the tutorial to create a pong game
+# using pygame at:
+# https://www.101computing.net/pong-tutorial-using-pygame-getting-started/
+
 import pygame
+from objects.paddle import Paddle
 
 # pygame setup
 pygame.init()
@@ -18,19 +22,11 @@ while running:
             running = False
 
     # fill the screen with a color to wipe away anything from last frame
-    screen.fill("purple")
+    screen.fill("black")
 
-    pygame.draw.circle(screen, "red", player_pos, 40)
-
-    keys = pygame.key.get_pressed()
-    if keys[pygame.K_w]:
-        player_pos.y -= 300 * dt
-    if keys[pygame.K_s]:
-        player_pos.y += 300 * dt
-    if keys[pygame.K_a]:
-        player_pos.x -= 300 * dt
-    if keys[pygame.K_d]:
-        player_pos.x += 300 * dt
+    # draw net, the vertical bar throught the center of the screen
+    pygame.draw.line(screen, "white", [screen.get_width() / 2, 0],
+                     [screen.get_width() / 2, screen.get_height() ], 5)
 
     # flip() the display to put your work on screen
     pygame.display.flip()

--- a/objects/paddle.py
+++ b/objects/paddle.py
@@ -1,0 +1,19 @@
+# This code was written using the following tutorial as a baseline:
+# https://www.101computing.net/pong-tutorial-using-pygame-adding-the-paddles/
+
+import pygame
+
+class Paddle(pygame.sprite.Sprite):
+    # This class represents a paddle. It derives from the "Sprite" class in Pygame.
+    # See this reference for more info on the "Sprite" class in Pygame:
+    # https://www.pygame.org/docs/ref/sprite.html?highlight=sprite#pygame.sprite.Sprite
+    def __init__(self, color, width, height):
+        super().__init__()
+
+        self.image = pygame.Surface([width, height])
+        self.image.fill("black")
+        self.image.set_colorkey("black")
+
+        pygame.draw.rect(self.image, color, [0, 0, width, height])
+
+        self.rect = self.image.get_rect()


### PR DESCRIPTION
## Purpose
This PR follows the guidelines in step 2 of the tutorial [here](https://www.101computing.net/pong-tutorial-using-pygame-adding-the-paddles/). I completed part of step 2, stopping before "Our First Object". This sets up the net (a vertical bar through the center of the screen), and provides the paddle class but does not actually create any of the paddles on the screen.

## Overview
- I added a few lines to the main game.py file, including an import of Paddle.
- Note that I departed a little from the tutorial by creating a subdirectory called `objects/` and put the code for the paddle in `objects/paddle.py`. This was in case we want to add more objects later, so they can all be on in one place.
- All of the deleted code is from the example provided by the pygame website, and we don't really need it.